### PR TITLE
Fix recipe editor slot interaction alignment

### DIFF
--- a/src/main/java/com/example/examplemod/menu/RecipeEditorMenu.java
+++ b/src/main/java/com/example/examplemod/menu/RecipeEditorMenu.java
@@ -30,20 +30,32 @@ public class RecipeEditorMenu extends AbstractContainerMenu {
 
         // Add input slots (left side)
         for (int i = 0; i < MAX_INPUT_SLOTS; i++) {
+            final int slotIndex = i;
             addSlot(new SlotItemHandler(inputItems, i, 8 + (i % 3) * 18, 17 + (i / 3) * 18) {
                 @Override
                 public boolean mayPlace(ItemStack stack) {
                     return true;
+                }
+
+                @Override
+                public boolean isActive() {
+                    return slotIndex < activeInputSlots;
                 }
             });
         }
 
         // Add output slots (right side)
         for (int i = 0; i < MAX_OUTPUT_SLOTS; i++) {
+            final int slotIndex = i;
             addSlot(new SlotItemHandler(outputItems, i, 116 + (i % 2) * 18, 26 + (i / 2) * 18) {
                 @Override
                 public boolean mayPlace(ItemStack stack) {
                     return true;
+                }
+
+                @Override
+                public boolean isActive() {
+                    return slotIndex < activeOutputSlots;
                 }
             });
         }
@@ -91,16 +103,16 @@ public class RecipeEditorMenu extends AbstractContainerMenu {
             ItemStack stack = slot.getItem();
             itemstack = stack.copy();
 
-            int containerSlots = MAX_INPUT_SLOTS + MAX_OUTPUT_SLOTS;
+            int containerSlotEnd = MAX_INPUT_SLOTS + MAX_OUTPUT_SLOTS;
 
-            if (index < containerSlots) {
+            if (index < containerSlotEnd) {
                 // Moving from container to player inventory
-                if (!this.moveItemStackTo(stack, containerSlots, this.slots.size(), true)) {
+                if (!this.moveItemStackTo(stack, containerSlotEnd, this.slots.size(), true)) {
                     return ItemStack.EMPTY;
                 }
             } else {
                 // Moving from player inventory to container (inputs only)
-                if (!this.moveItemStackTo(stack, 0, MAX_INPUT_SLOTS, false)) {
+                if (activeInputSlots == 0 || !this.moveItemStackTo(stack, 0, activeInputSlots, false)) {
                     return ItemStack.EMPTY;
                 }
             }


### PR DESCRIPTION
## Summary
- align the recipe editor's drawn slot backgrounds with the underlying menu slot coordinates
- deactivate hidden input/output slots and limit quick-move behavior so clicks and transfers target the expected positions

## Testing
- `bash ./gradlew build` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913556676148330b0e508e84113c3cc)