### PR TITLE
Allow recipe editor slots to move via reflection

### DIFF
--- a/src/main/java/com/example/examplemod/client/RecipeEditorScreen.java
+++ b/src/main/java/com/example/examplemod/client/RecipeEditorScreen.java
@@ -147,19 +147,19 @@ public class RecipeEditorScreen extends AbstractContainerScreen<RecipeEditorMenu
         String recipeType = selectedRecipeType.toLowerCase();
 
         if (recipeType.contains("shaped") || recipeType.contains("crafting_shaped")) {
-            menu.setActiveSlots(9, 1); // 3x3 crafting grid, 1 output
+            menu.setActiveSlots(9, 1, 3, 1); // 3x3 crafting grid, 1 output
         } else if (recipeType.contains("shapeless") || recipeType.contains("crafting_shapeless")) {
-            menu.setActiveSlots(9, 1); // Up to 9 inputs, 1 output
+            menu.setActiveSlots(9, 1, 3, 1); // Up to 9 inputs, 1 output
         } else if (recipeType.contains("smelting") || recipeType.contains("blasting") ||
                    recipeType.contains("smoking") || recipeType.contains("campfire")) {
-            menu.setActiveSlots(1, 1); // 1 input, 1 output
+            menu.setActiveSlots(1, 1, 1, 1); // 1 input, 1 output
         } else if (recipeType.contains("stonecutting")) {
-            menu.setActiveSlots(1, 1); // 1 input, 1 output
+            menu.setActiveSlots(1, 1, 1, 1); // 1 input, 1 output
         } else if (recipeType.contains("smithing")) {
-            menu.setActiveSlots(3, 1); // Template, base, addition -> output
+            menu.setActiveSlots(3, 1, 3, 1); // Template, base, addition -> output
         } else {
             // Default configuration
-            menu.setActiveSlots(3, 2); // 3 inputs, 2 outputs
+            menu.setActiveSlots(3, 2, 3, 2); // 3 inputs, 2 outputs
         }
     }
 

--- a/src/main/java/com/example/examplemod/menu/MovableSlotItemHandler.java
+++ b/src/main/java/com/example/examplemod/menu/MovableSlotItemHandler.java
@@ -1,0 +1,48 @@
+package com.example.examplemod.menu;
+
+import java.lang.reflect.Field;
+
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.SlotItemHandler;
+
+/**
+ * A {@link SlotItemHandler} that can adjust its on-screen position after construction.
+ */
+class MovableSlotItemHandler extends SlotItemHandler {
+    private static final Field X_FIELD;
+    private static final Field Y_FIELD;
+
+    static {
+        try {
+            X_FIELD = Slot.class.getDeclaredField("x");
+            Y_FIELD = Slot.class.getDeclaredField("y");
+            X_FIELD.setAccessible(true);
+            Y_FIELD.setAccessible(true);
+        } catch (NoSuchFieldException e) {
+            throw new IllegalStateException("Failed to access Slot position fields", e);
+        }
+    }
+
+    MovableSlotItemHandler(IItemHandler itemHandler, int index, int xPosition, int yPosition) {
+        super(itemHandler, index, xPosition, yPosition);
+    }
+
+    /**
+     * Updates the rendered position of this slot.
+     */
+    void setPosition(int xPosition, int yPosition) {
+        try {
+            X_FIELD.setInt(this, xPosition);
+            Y_FIELD.setInt(this, yPosition);
+        } catch (IllegalAccessException e) {
+            throw new IllegalStateException("Unable to reposition slot", e);
+        }
+    }
+
+    @Override
+    public boolean mayPlace(ItemStack stack) {
+        return true;
+    }
+}

--- a/src/main/java/com/example/examplemod/menu/RecipeEditorMenu.java
+++ b/src/main/java/com/example/examplemod/menu/RecipeEditorMenu.java
@@ -7,7 +7,6 @@ import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.items.ItemStackHandler;
-import net.minecraftforge.items.SlotItemHandler;
 
 /**
  * Container menu for the recipe editor GUI.
@@ -19,11 +18,19 @@ public class RecipeEditorMenu extends AbstractContainerMenu {
     private static final int MAX_INPUT_SLOTS = 9;
     private static final int MAX_OUTPUT_SLOTS = 4;
 
+    private static final int SLOT_SPACING = 18;
+    private static final int INPUT_START_X = 8;
+    private static final int INPUT_START_Y = 17;
+    private static final int OUTPUT_START_X = 116;
+    private static final int OUTPUT_START_Y = 26;
+
     private final ItemStackHandler inputItems = new ItemStackHandler(MAX_INPUT_SLOTS);
     private final ItemStackHandler outputItems = new ItemStackHandler(MAX_OUTPUT_SLOTS);
 
     private int activeInputSlots = 1;  // How many input slots are currently visible
     private int activeOutputSlots = 1; // How many output slots are currently visible
+    private int inputColumns = 1;
+    private int outputColumns = 1;
 
     public RecipeEditorMenu(int id, Inventory playerInventory) {
         super(ModMenuTypes.RECIPE_EDITOR.get(), id);
@@ -31,12 +38,9 @@ public class RecipeEditorMenu extends AbstractContainerMenu {
         // Add input slots (left side)
         for (int i = 0; i < MAX_INPUT_SLOTS; i++) {
             final int slotIndex = i;
-            addSlot(new SlotItemHandler(inputItems, i, 8 + (i % 3) * 18, 17 + (i / 3) * 18) {
-                @Override
-                public boolean mayPlace(ItemStack stack) {
-                    return true;
-                }
-
+            addSlot(new MovableSlotItemHandler(inputItems, i,
+                INPUT_START_X + (i % 3) * SLOT_SPACING,
+                INPUT_START_Y + (i / 3) * SLOT_SPACING) {
                 @Override
                 public boolean isActive() {
                     return slotIndex < activeInputSlots;
@@ -47,12 +51,9 @@ public class RecipeEditorMenu extends AbstractContainerMenu {
         // Add output slots (right side)
         for (int i = 0; i < MAX_OUTPUT_SLOTS; i++) {
             final int slotIndex = i;
-            addSlot(new SlotItemHandler(outputItems, i, 116 + (i % 2) * 18, 26 + (i / 2) * 18) {
-                @Override
-                public boolean mayPlace(ItemStack stack) {
-                    return true;
-                }
-
+            addSlot(new MovableSlotItemHandler(outputItems, i,
+                OUTPUT_START_X + (i % 2) * SLOT_SPACING,
+                OUTPUT_START_Y + (i / 2) * SLOT_SPACING) {
                 @Override
                 public boolean isActive() {
                     return slotIndex < activeOutputSlots;
@@ -82,8 +83,18 @@ public class RecipeEditorMenu extends AbstractContainerMenu {
     }
 
     public void setActiveSlots(int inputs, int outputs) {
-        this.activeInputSlots = Math.min(inputs, MAX_INPUT_SLOTS);
-        this.activeOutputSlots = Math.min(outputs, MAX_OUTPUT_SLOTS);
+        setActiveSlots(inputs, outputs, 3, 2);
+    }
+
+    public void setActiveSlots(int inputs, int outputs, int requestedInputColumns, int requestedOutputColumns) {
+        this.activeInputSlots = Math.min(Math.max(inputs, 0), MAX_INPUT_SLOTS);
+        this.activeOutputSlots = Math.min(Math.max(outputs, 0), MAX_OUTPUT_SLOTS);
+
+        this.inputColumns = Math.max(1, Math.min(requestedInputColumns, MAX_INPUT_SLOTS));
+        this.outputColumns = Math.max(1, Math.min(requestedOutputColumns, MAX_OUTPUT_SLOTS));
+
+        updateInputSlotPositions();
+        updateOutputSlotPositions();
     }
 
     public int getActiveInputSlots() {
@@ -92,6 +103,37 @@ public class RecipeEditorMenu extends AbstractContainerMenu {
 
     public int getActiveOutputSlots() {
         return activeOutputSlots;
+    }
+
+    private void updateInputSlotPositions() {
+        int totalSlots = Math.min(MAX_INPUT_SLOTS, this.slots.size());
+        for (int i = 0; i < totalSlots; i++) {
+            Slot slot = this.slots.get(i);
+            if (slot instanceof MovableSlotItemHandler movableSlot) {
+                int column = i % inputColumns;
+                int row = i / inputColumns;
+
+                movableSlot.setPosition(INPUT_START_X + column * SLOT_SPACING, INPUT_START_Y + row * SLOT_SPACING);
+            }
+        }
+    }
+
+    private void updateOutputSlotPositions() {
+        int baseIndex = MAX_INPUT_SLOTS;
+        for (int i = 0; i < MAX_OUTPUT_SLOTS; i++) {
+            int slotListIndex = baseIndex + i;
+            if (slotListIndex >= this.slots.size()) {
+                break;
+            }
+
+            Slot slot = this.slots.get(slotListIndex);
+            if (slot instanceof MovableSlotItemHandler movableSlot) {
+                int column = i % outputColumns;
+                int row = i / outputColumns;
+
+                movableSlot.setPosition(OUTPUT_START_X + column * SLOT_SPACING, OUTPUT_START_Y + row * SLOT_SPACING);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary
- add a MovableSlotItemHandler helper that updates slot coordinates through reflection
- use the movable slot helper in RecipeEditorMenu so input and output layouts reposition without overlapping

## Testing
- not run (per user request)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69138b0520108330834e618b789598d3)