### PR TITLE
Remove example item and refresh mod branding

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ loader_version_range=[47,)
 # Must match the String constant located in the main mod class annotated with @Mod.
 mod_id=examplemod
 # The human-readable display name for the mod.
-mod_name=Example Mod
+mod_name=KubeJS GUI
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=All Rights Reserved
 # The mod version. See https://semver.org/

--- a/src/main/java/com/example/examplemod/ExampleMod.java
+++ b/src/main/java/com/example/examplemod/ExampleMod.java
@@ -4,12 +4,9 @@ import com.example.examplemod.network.ModNetworking;
 import com.example.examplemod.registry.ModMenuTypes;
 import com.mojang.logging.LogUtils;
 import net.minecraft.client.Minecraft;
-import net.minecraft.core.registries.Registries;
-import net.minecraft.world.food.FoodProperties;
 import net.minecraft.world.item.BlockItem;
-import net.minecraft.world.item.CreativeModeTab;
-import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockBehaviour;
@@ -43,25 +40,10 @@ public class ExampleMod
     public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MODID);
     // Create a Deferred Register to hold Items which will all be registered under the "examplemod" namespace
     public static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
-    // Create a Deferred Register to hold CreativeModeTabs which will all be registered under the "examplemod" namespace
-    public static final DeferredRegister<CreativeModeTab> CREATIVE_MODE_TABS = DeferredRegister.create(Registries.CREATIVE_MODE_TAB, MODID);
-
     // Creates a new Block with the id "examplemod:example_block", combining the namespace and path
     public static final RegistryObject<Block> EXAMPLE_BLOCK = BLOCKS.register("example_block", () -> new Block(BlockBehaviour.Properties.of().mapColor(MapColor.STONE)));
     // Creates a new BlockItem with the id "examplemod:example_block", combining the namespace and path
     public static final RegistryObject<Item> EXAMPLE_BLOCK_ITEM = ITEMS.register("example_block", () -> new BlockItem(EXAMPLE_BLOCK.get(), new Item.Properties()));
-
-    // Creates a new food item with the id "examplemod:example_id", nutrition 1 and saturation 2
-    public static final RegistryObject<Item> EXAMPLE_ITEM = ITEMS.register("example_item", () -> new Item(new Item.Properties().food(new FoodProperties.Builder()
-            .alwaysEat().nutrition(1).saturationMod(2f).build())));
-
-    // Creates a creative tab with the id "examplemod:example_tab" for the example item, that is placed after the combat tab
-    public static final RegistryObject<CreativeModeTab> EXAMPLE_TAB = CREATIVE_MODE_TABS.register("example_tab", () -> CreativeModeTab.builder()
-            .withTabsBefore(CreativeModeTabs.COMBAT)
-            .icon(() -> EXAMPLE_ITEM.get().getDefaultInstance())
-            .displayItems((parameters, output) -> {
-                output.accept(EXAMPLE_ITEM.get()); // Add the example item to the tab. For your own tabs, this method is preferred over the event
-            }).build());
 
     public ExampleMod()
     {
@@ -74,8 +56,6 @@ public class ExampleMod
         BLOCKS.register(modEventBus);
         // Register the Deferred Register to the mod event bus so items get registered
         ITEMS.register(modEventBus);
-        // Register the Deferred Register to the mod event bus so tabs get registered
-        CREATIVE_MODE_TABS.register(modEventBus);
         // Register menu types
         ModMenuTypes.MENUS.register(modEventBus);
 

--- a/src/main/java/com/example/examplemod/client/RecipeEditorScreen.java
+++ b/src/main/java/com/example/examplemod/client/RecipeEditorScreen.java
@@ -76,28 +76,28 @@ public class RecipeEditorScreen extends AbstractContainerScreen<RecipeEditorMenu
         this.modFilterButton = Button.builder(
             Component.literal("Mod: " + selectedMod),
             button -> cycleModFilter()
-        ).bounds(buttonX, buttonY + 22, 85, 20).build();
+        ).bounds(buttonX, buttonY + 22, 102, 20).build();
         this.addRenderableWidget(modFilterButton);
 
         // Recipe type button (left side)
         this.recipeTypeButton = Button.builder(
             Component.literal(getShortRecipeTypeName()),
             button -> cycleRecipeType()
-        ).bounds(buttonX, buttonY + 44, 85, 20).build();
+        ).bounds(buttonX, buttonY + 44, 102, 20).build();
         this.addRenderableWidget(recipeTypeButton);
 
         // Export button (left side)
         this.exportButton = Button.builder(
             Component.literal("Export"),
             button -> exportRecipe()
-        ).bounds(buttonX, buttonY + 66, 85, 20).build();
+        ).bounds(buttonX, buttonY + 66, 102, 20).build();
         this.addRenderableWidget(exportButton);
 
         // Clear button (left side)
         this.clearButton = Button.builder(
             Component.literal("Clear"),
             button -> clearRecipe()
-        ).bounds(buttonX, buttonY + 88, 85, 20).build();
+        ).bounds(buttonX, buttonY + 88, 102, 20).build();
         this.addRenderableWidget(clearButton);
 
         updateSlotConfiguration();
@@ -245,7 +245,6 @@ public class RecipeEditorScreen extends AbstractContainerScreen<RecipeEditorMenu
     @Override
     protected void renderLabels(GuiGraphics guiGraphics, int mouseX, int mouseY) {
         guiGraphics.drawString(this.font, this.title, this.titleLabelX, this.titleLabelY, 4210752, false);
-        guiGraphics.drawString(this.font, this.playerInventoryTitle, this.inventoryLabelX, this.inventoryLabelY, 4210752, false);
     }
 
     @Override

--- a/src/main/java/com/example/examplemod/recipe/RecipeTypeRegistry.java
+++ b/src/main/java/com/example/examplemod/recipe/RecipeTypeRegistry.java
@@ -48,6 +48,10 @@ public class RecipeTypeRegistry {
             String modId = typeId.getNamespace();
             String recipePath = typeId.getPath();
 
+            if ("crafting".equals(recipePath)) {
+                continue;
+            }
+
             RecipeTypeInfo info = new RecipeTypeInfo(typeId, modId, recipePath);
 
             recipeTypesByMod.computeIfAbsent(modId, k -> new ArrayList<>()).add(info);

--- a/src/main/resources/assets/examplemod/lang/en_us.json
+++ b/src/main/resources/assets/examplemod/lang/en_us.json
@@ -1,7 +1,5 @@
 {
-  "itemGroup.examplemod": "Example Mod Tab",
   "block.examplemod.example_block": "Example Block",
-  "item.examplemod.example_item": "Example Item",
-  "key.categories.examplemod": "Example Mod",
+  "key.categories.examplemod": "KubeJS GUI",
   "key.examplemod.open_gui": "Open Blank GUI"
 }


### PR DESCRIPTION
## Summary
- remove the leftover example item and associated creative tab registration
- widen recipe editor buttons and hide the inventory label text
- filter out the generic crafting recipe type and rename the mod display strings to KubeJS GUI

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913b80c802c833082944084d177ead7)