### PR TITLE
Rename mod id and packages from examplemod to kubejsgui

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,7 @@ loader_version_range=[47,)
 
 # The unique mod identifier for the mod. Must be lowercase in English locale. Must fit the regex [a-z][a-z0-9_]{1,63}
 # Must match the String constant located in the main mod class annotated with @Mod.
-mod_id=examplemod
+mod_id=kubejsgui
 # The human-readable display name for the mod.
 mod_name=Example Mod
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
@@ -38,7 +38,7 @@ mod_version=1.0.5
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html
-mod_group_id=com.example.examplemod
+mod_group_id=com.example.kubejsgui
 # The authors of the mod. This is a simple text string that is used for display purposes in the mod list.
 mod_authors=YourNameHere, OtherNameHere
 # The description of the mod. This is a simple multiline text string that is used for display purposes in the mod list.

--- a/src/main/java/com/example/kubejsgui/Config.java
+++ b/src/main/java/com/example/kubejsgui/Config.java
@@ -1,4 +1,4 @@
-package com.example.examplemod;
+package com.example.kubejsgui;
 
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;

--- a/src/main/java/com/example/kubejsgui/ExampleMod.java
+++ b/src/main/java/com/example/kubejsgui/ExampleMod.java
@@ -1,7 +1,7 @@
-package com.example.examplemod;
+package com.example.kubejsgui;
 
-import com.example.examplemod.network.ModNetworking;
-import com.example.examplemod.registry.ModMenuTypes;
+import com.example.kubejsgui.network.ModNetworking;
+import com.example.kubejsgui.registry.ModMenuTypes;
 import com.mojang.logging.LogUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.registries.Registries;
@@ -36,26 +36,26 @@ import org.slf4j.Logger;
 public class ExampleMod
 {
     // Define mod id in a common place for everything to reference
-    public static final String MODID = "examplemod";
+    public static final String MODID = "kubejsgui";
     // Directly reference a slf4j logger
     private static final Logger LOGGER = LogUtils.getLogger();
-    // Create a Deferred Register to hold Blocks which will all be registered under the "examplemod" namespace
+    // Create a Deferred Register to hold Blocks which will all be registered under the "kubejsgui" namespace
     public static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(ForgeRegistries.BLOCKS, MODID);
-    // Create a Deferred Register to hold Items which will all be registered under the "examplemod" namespace
+    // Create a Deferred Register to hold Items which will all be registered under the "kubejsgui" namespace
     public static final DeferredRegister<Item> ITEMS = DeferredRegister.create(ForgeRegistries.ITEMS, MODID);
-    // Create a Deferred Register to hold CreativeModeTabs which will all be registered under the "examplemod" namespace
+    // Create a Deferred Register to hold CreativeModeTabs which will all be registered under the "kubejsgui" namespace
     public static final DeferredRegister<CreativeModeTab> CREATIVE_MODE_TABS = DeferredRegister.create(Registries.CREATIVE_MODE_TAB, MODID);
 
-    // Creates a new Block with the id "examplemod:example_block", combining the namespace and path
+    // Creates a new Block with the id "kubejsgui:example_block", combining the namespace and path
     public static final RegistryObject<Block> EXAMPLE_BLOCK = BLOCKS.register("example_block", () -> new Block(BlockBehaviour.Properties.of().mapColor(MapColor.STONE)));
-    // Creates a new BlockItem with the id "examplemod:example_block", combining the namespace and path
+    // Creates a new BlockItem with the id "kubejsgui:example_block", combining the namespace and path
     public static final RegistryObject<Item> EXAMPLE_BLOCK_ITEM = ITEMS.register("example_block", () -> new BlockItem(EXAMPLE_BLOCK.get(), new Item.Properties()));
 
-    // Creates a new food item with the id "examplemod:example_id", nutrition 1 and saturation 2
+    // Creates a new food item with the id "kubejsgui:example_id", nutrition 1 and saturation 2
     public static final RegistryObject<Item> EXAMPLE_ITEM = ITEMS.register("example_item", () -> new Item(new Item.Properties().food(new FoodProperties.Builder()
             .alwaysEat().nutrition(1).saturationMod(2f).build())));
 
-    // Creates a creative tab with the id "examplemod:example_tab" for the example item, that is placed after the combat tab
+    // Creates a creative tab with the id "kubejsgui:example_tab" for the example item, that is placed after the combat tab
     public static final RegistryObject<CreativeModeTab> EXAMPLE_TAB = CREATIVE_MODE_TABS.register("example_tab", () -> CreativeModeTab.builder()
             .withTabsBefore(CreativeModeTabs.COMBAT)
             .icon(() -> EXAMPLE_ITEM.get().getDefaultInstance())

--- a/src/main/java/com/example/kubejsgui/client/BlankInventoryScreen.java
+++ b/src/main/java/com/example/kubejsgui/client/BlankInventoryScreen.java
@@ -1,4 +1,4 @@
-package com.example.examplemod.client;
+package com.example.kubejsgui.client;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;

--- a/src/main/java/com/example/kubejsgui/client/ClientEvents.java
+++ b/src/main/java/com/example/kubejsgui/client/ClientEvents.java
@@ -1,7 +1,7 @@
-package com.example.examplemod.client;
+package com.example.kubejsgui.client;
 
-import com.example.examplemod.network.ModNetworking;
-import com.example.examplemod.network.OpenRecipeEditorPacket;
+import com.example.kubejsgui.network.ModNetworking;
+import com.example.kubejsgui.network.OpenRecipeEditorPacket;
 import net.minecraft.client.Minecraft;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.RegisterKeyMappingsEvent;

--- a/src/main/java/com/example/kubejsgui/client/KeyBindings.java
+++ b/src/main/java/com/example/kubejsgui/client/KeyBindings.java
@@ -1,4 +1,4 @@
-package com.example.examplemod.client;
+package com.example.kubejsgui.client;
 
 import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
 import net.minecraft.client.KeyMapping;
@@ -7,8 +7,8 @@ import com.mojang.blaze3d.platform.InputConstants;
 import org.lwjgl.glfw.GLFW;
 
 public class KeyBindings {
-    public static final String CATEGORY = "key.categories.examplemod";
-    public static final String OPEN_GUI = "key.examplemod.open_gui";
+    public static final String CATEGORY = "key.categories.kubejsgui";
+    public static final String OPEN_GUI = "key.kubejsgui.open_gui";
 
     public static KeyMapping OPEN_GUI_KEY;
 

--- a/src/main/java/com/example/kubejsgui/client/RecipeEditorScreen.java
+++ b/src/main/java/com/example/kubejsgui/client/RecipeEditorScreen.java
@@ -1,8 +1,8 @@
-package com.example.examplemod.client;
+package com.example.kubejsgui.client;
 
-import com.example.examplemod.menu.RecipeEditorMenu;
-import com.example.examplemod.recipe.RecipeTypeRegistry;
-import com.example.examplemod.util.KubeJSExporter;
+import com.example.kubejsgui.menu.RecipeEditorMenu;
+import com.example.kubejsgui.recipe.RecipeTypeRegistry;
+import com.example.kubejsgui.util.KubeJSExporter;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;

--- a/src/main/java/com/example/kubejsgui/client/ScreenRegistry.java
+++ b/src/main/java/com/example/kubejsgui/client/ScreenRegistry.java
@@ -1,6 +1,6 @@
-package com.example.examplemod.client;
+package com.example.kubejsgui.client;
 
-import com.example.examplemod.registry.ModMenuTypes;
+import com.example.kubejsgui.registry.ModMenuTypes;
 import net.minecraft.client.gui.screens.MenuScreens;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.eventbus.api.SubscribeEvent;

--- a/src/main/java/com/example/kubejsgui/menu/RecipeEditorMenu.java
+++ b/src/main/java/com/example/kubejsgui/menu/RecipeEditorMenu.java
@@ -1,6 +1,6 @@
-package com.example.examplemod.menu;
+package com.example.kubejsgui.menu;
 
-import com.example.examplemod.registry.ModMenuTypes;
+import com.example.kubejsgui.registry.ModMenuTypes;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.inventory.AbstractContainerMenu;

--- a/src/main/java/com/example/kubejsgui/network/ModNetworking.java
+++ b/src/main/java/com/example/kubejsgui/network/ModNetworking.java
@@ -1,6 +1,6 @@
-package com.example.examplemod.network;
+package com.example.kubejsgui.network;
 
-import com.example.examplemod.ExampleMod;
+import com.example.kubejsgui.ExampleMod;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.network.NetworkRegistry;
 import net.minecraftforge.network.simple.SimpleChannel;

--- a/src/main/java/com/example/kubejsgui/network/OpenRecipeEditorPacket.java
+++ b/src/main/java/com/example/kubejsgui/network/OpenRecipeEditorPacket.java
@@ -1,6 +1,6 @@
-package com.example.examplemod.network;
+package com.example.kubejsgui.network;
 
-import com.example.examplemod.menu.RecipeEditorMenu;
+import com.example.kubejsgui.menu.RecipeEditorMenu;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;

--- a/src/main/java/com/example/kubejsgui/recipe/RecipeTypeRegistry.java
+++ b/src/main/java/com/example/kubejsgui/recipe/RecipeTypeRegistry.java
@@ -1,4 +1,4 @@
-package com.example.examplemod.recipe;
+package com.example.kubejsgui.recipe;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.resources.ResourceLocation;

--- a/src/main/java/com/example/kubejsgui/registry/ModMenuTypes.java
+++ b/src/main/java/com/example/kubejsgui/registry/ModMenuTypes.java
@@ -1,7 +1,7 @@
-package com.example.examplemod.registry;
+package com.example.kubejsgui.registry;
 
-import com.example.examplemod.ExampleMod;
-import com.example.examplemod.menu.RecipeEditorMenu;
+import com.example.kubejsgui.ExampleMod;
+import com.example.kubejsgui.menu.RecipeEditorMenu;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraftforge.common.extensions.IForgeMenuType;
 import net.minecraftforge.registries.DeferredRegister;

--- a/src/main/java/com/example/kubejsgui/util/KubeJSExporter.java
+++ b/src/main/java/com/example/kubejsgui/util/KubeJSExporter.java
@@ -1,4 +1,4 @@
-package com.example.examplemod.util;
+package com.example.kubejsgui.util;
 
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.items.ItemStackHandler;

--- a/src/main/resources/assets/examplemod/lang/en_us.json
+++ b/src/main/resources/assets/examplemod/lang/en_us.json
@@ -1,7 +1,0 @@
-{
-  "itemGroup.examplemod": "Example Mod Tab",
-  "block.examplemod.example_block": "Example Block",
-  "item.examplemod.example_item": "Example Item",
-  "key.categories.examplemod": "Example Mod",
-  "key.examplemod.open_gui": "Open Blank GUI"
-}

--- a/src/main/resources/assets/kubejsgui/lang/en_us.json
+++ b/src/main/resources/assets/kubejsgui/lang/en_us.json
@@ -1,0 +1,7 @@
+{
+  "itemGroup.kubejsgui": "Example Mod Tab",
+  "block.kubejsgui.example_block": "Example Block",
+  "item.kubejsgui.example_item": "Example Item",
+  "key.categories.kubejsgui": "Example Mod",
+  "key.kubejsgui.open_gui": "Open Blank GUI"
+}

--- a/src/main/templates/META-INF/mods.toml
+++ b/src/main/templates/META-INF/mods.toml
@@ -38,7 +38,7 @@ displayName="${mod_name}" #mandatory
 #displayURL="https://change.me.to.your.mods.homepage.example.invalid/" #optional
 
 # A file name (in the root of the mod JAR) containing a logo for display
-#logoFile="examplemod.png" #optional
+#logoFile="kubejsgui.png" #optional
 
 # A text field displayed in the mod UI
 #credits="" #optional


### PR DESCRIPTION
### Motivation
- Prevent namespace collisions with other mods named `examplemod` by switching the mod id and package to a unique `kubejsgui` identifier.
- Ensure Java package names, resource keys, and build metadata consistently reflect the new mod id. 
- Keep resource/asset paths aligned with the updated namespace so in-game localization and assets resolve correctly.

### Description
- Updated mod properties in `gradle.properties` by changing `mod_id` to `kubejsgui` and `mod_group_id` to `com.example.kubejsgui`.
- Renamed the Java package from `com.example.examplemod` to `com.example.kubejsgui` and updated package declarations and imports across source files under `src/main/java`.
- Changed the mod id constant `ExampleMod.MODID` to `"kubejsgui"` and updated related comments and registry usages to the new namespace.
- Moved localization assets from `src/main/resources/assets/examplemod` to `src/main/resources/assets/kubejsgui` and updated localization keys; updated `mods.toml` to reference `kubejsgui.png` for the optional logo.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b905a4718833094feda59c9a36315)